### PR TITLE
[104] Remove confusing todos

### DIFF
--- a/mdc_100_series/lib/app.dart
+++ b/mdc_100_series/lib/app.dart
@@ -21,8 +21,6 @@ import 'supplemental/cut_corners_border.dart';
 
 // TODO: Convert ShrineApp to stateful widget (104)
 class ShrineApp extends StatelessWidget {
-  // TODO: Add variable for selected Category (104)
-  // TODO: Add a callback when a Category is tapped (104)
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
In #64, it was pointed out that these todos don't move to the new _ShrineAppState when it is created in 104. Since the todos are supposed to go inside of _ShrineAppState, it is confusing for them to stay in ShrineApp. 

Instead of trying to get learners to move the todos manually, it's probably clearer and simpler to just get rid of them entirely.