### PR TITLE
[101] Update import for app.dart in main.dart

### DIFF
--- a/mdc_100_series/lib/main.dart
+++ b/mdc_100_series/lib/main.dart
@@ -14,6 +14,6 @@
 
 import 'package:flutter/material.dart';
 
-import 'app.dart';
+import 'package:Shrine/app.dart';
 
 void main() => runApp(ShrineApp());


### PR DESCRIPTION
Prevents type errors due to this import in future codelabs.

This fixes issues users had in #81 and #82 (type mismatch for objects that should have been the same type) that were due to the wrong type of import in `main.dart` - more information is in [dart-lang/sdk#33076](https://github.com/dart-lang/sdk/issues/33076).