### PR TITLE
[102-104] Fix semanticLabels for buttons that return to login

### DIFF
--- a/mdc_100_series/lib/home.dart
+++ b/mdc_100_series/lib/home.dart
@@ -98,7 +98,7 @@ class HomePage extends StatelessWidget {
           IconButton(
             icon: Icon(
               Icons.search,
-              semanticLabel: 'search',
+              semanticLabel: 'login',
             ),
             onPressed: () {
               print('Search button');
@@ -107,7 +107,7 @@ class HomePage extends StatelessWidget {
           IconButton(
             icon: Icon(
               Icons.tune,
-              semanticLabel: 'filter',
+              semanticLabel: 'login',
             ),
             onPressed: () {
               print('Filter button');


### PR DESCRIPTION
The IconButtons currently announce the names of the icons, are changed to announce the page to which they lead. Closes #85.