### PR TITLE
[104] Prevent products from scrolling vertically within columns

### DIFF
--- a/mdc_100_series/lib/supplemental/product_columns.dart
+++ b/mdc_100_series/lib/supplemental/product_columns.dart
@@ -39,6 +39,7 @@ class TwoProductCardColumn extends StatelessWidget {
               : 33 / 49;
 
           return ListView(
+            physics: ClampingScrollPhysics(),
             children: <Widget>[
               Padding(
                 padding: EdgeInsetsDirectional.only(start: 28.0),
@@ -74,6 +75,7 @@ class OneProductCardColumn extends StatelessWidget {
   Widget build(BuildContext context) {
     return ListView(
       reverse: true,
+      physics: ClampingScrollPhysics(),
       children: <Widget>[
         SizedBox(
           height: 40.0,


### PR DESCRIPTION
The list views that hold the products in product columns are currently scrollable (can be moved vertically). This would make them not scrollable.