### PR TITLE
[102-103] Revert semantic label changes

### DIFF
--- a/mdc_100_series/lib/home.dart
+++ b/mdc_100_series/lib/home.dart
@@ -98,7 +98,7 @@ class HomePage extends StatelessWidget {
           IconButton(
             icon: Icon(
               Icons.search,
-              semanticLabel: 'login',
+              semanticLabel: 'search',
             ),
             onPressed: () {
               print('Search button');
@@ -107,7 +107,7 @@ class HomePage extends StatelessWidget {
           IconButton(
             icon: Icon(
               Icons.tune,
-              semanticLabel: 'login',
+              semanticLabel: 'filter',
             ),
             onPressed: () {
               print('Filter button');


### PR DESCRIPTION
I realized that the buttons don't link to the login page until 104, so the 'login' semantic label should be removed through 103-complete-104-starter.