### PR TITLE
don't lock shrine_images' version

### DIFF
--- a/mdc_100_series/pubspec.yaml
+++ b/mdc_100_series/pubspec.yaml
@@ -7,7 +7,7 @@ dependencies:
   intl: ^0.15.6
 
   cupertino_icons: ^0.1.0
-  shrine_images: 1.0.0
+  shrine_images:
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Don't lock the version of `shrine_images` otherwise we might end up with unresolvable dependencies:

```
Because Shrine depends on shrine_images <1.1.1 which requires SDK version >=1.19.0 <2.1.0, version solving failed.
```