### PR TITLE
Add const to ClampingScrollPhysics

### DIFF
--- a/mdc_100_series/lib/supplemental/product_columns.dart
+++ b/mdc_100_series/lib/supplemental/product_columns.dart
@@ -39,7 +39,7 @@ class TwoProductCardColumn extends StatelessWidget {
               : 33 / 49;
 
           return ListView(
-            physics: ClampingScrollPhysics(),
+            physics: const ClampingScrollPhysics(),
             children: <Widget>[
               Padding(
                 padding: EdgeInsetsDirectional.only(start: 28.0),
@@ -75,7 +75,7 @@ class OneProductCardColumn extends StatelessWidget {
   Widget build(BuildContext context) {
     return ListView(
       reverse: true,
-      physics: ClampingScrollPhysics(),
+      physics: const ClampingScrollPhysics(),
       children: <Widget>[
         SizedBox(
           height: 40.0,


### PR DESCRIPTION
Adds `const`s before the `ClampingScrollPhysics()` in `product_columns.dart`, per review feedback on https://github.com/flutter/flutter/pull/27217.