### PR TITLE
Update shrine theme to have correct color on login buttons

### DIFF
--- a/mdc_100_series/lib/app.dart
+++ b/mdc_100_series/lib/app.dart
@@ -64,7 +64,12 @@ ThemeData _buildShrineTheme() {
     errorColor: kShrineErrorRed,
     buttonTheme: base.buttonTheme.copyWith(
       buttonColor: kShrinePink100,
-      textTheme: ButtonTextTheme.normal,
+      colorScheme: base.colorScheme.copyWith(
+        secondary: kShrineBrown900,
+      ),
+    ),
+    buttonBarTheme: base.buttonBarTheme.copyWith(
+      buttonTextTheme: ButtonTextTheme.accent,
     ),
     primaryIconTheme: base.iconTheme.copyWith(
         color: kShrineBrown900

--- a/mdc_100_series/pubspec.yaml
+++ b/mdc_100_series/pubspec.yaml
@@ -17,6 +17,7 @@ flutter:
   uses-material-design: true
   assets:
     - assets/diamond.png
+    # TODO: Add slanted menu asset (104)
     - packages/shrine_images/0-0.jpg
     - packages/shrine_images/1-0.jpg
     - packages/shrine_images/2-0.jpg


### PR DESCRIPTION
This will be merged in together with changes to the codelab.

Before:
![Simulator Screen Shot - iPhone 11 Pro Max - 2020-02-12 at 12 13 12](https://user-images.githubusercontent.com/1770678/74330124-664adb80-4d91-11ea-94b3-63a3df3a737b.png)

After:
![Simulator Screen Shot - iPhone 11 Pro Max - 2020-02-12 at 12 28 52](https://user-images.githubusercontent.com/1770678/74331108-3e5c7780-4d93-11ea-8030-d8242ae36c7c.png)

Closes https://github.com/material-components/material-components-flutter-codelabs/issues/171