### PR TITLE
Update textstyles on home.dart

### DIFF
--- a/mdc_100_series/lib/home.dart
+++ b/mdc_100_series/lib/home.dart
@@ -57,17 +57,15 @@ class HomePage extends StatelessWidget {
                   // TODO: Change innermost Column (103)
                   children: <Widget>[
                     // TODO: Handle overflowing labels (103)
-                    // TODO(larche): Make headline6 when available
                     Text(
                       product.name,
-                      style: theme.textTheme.title,
+                      style: theme.textTheme.headline6,
                       maxLines: 1,
                     ),
                     SizedBox(height: 8.0),
-                    // TODO(larche): Make subtitle2 when available
                     Text(
                       formatter.format(product.price),
-                      style: theme.textTheme.body2,
+                      style: theme.textTheme.subtitle2,
                     ),
                   ],
                 ),


### PR DESCRIPTION
Updating textstyles on home.dart by replacing deprecated textThemes with the new ones :)

**Edit:** I guess the codelab textstyle related instructions should be updated too? 🤔 . However haven't found where they are.

```
TextTheme _buildShrineTextTheme(TextTheme base) {
  return base.copyWith(
    headline: base.headline.copyWith(
      fontWeight: FontWeight.w500,
    ),
    title: base.title.copyWith(
        fontSize: 18.0
    ),
    caption: base.caption.copyWith(
      fontWeight: FontWeight.w400,
      fontSize: 14.0,
    ),
  ).apply(
    fontFamily: 'Rubik',
    displayColor: kShrineBrown900,
    bodyColor: kShrineBrown900,
  );
}
```

To

```
TextTheme _buildShrineTextTheme(TextTheme base) {
  return base
      .copyWith(
        headline5: base.headline5.copyWith(
          fontWeight: FontWeight.w500,
        ),
        headline6: base.headline6.copyWith(fontSize: 18.0),
        caption: base.caption.copyWith(
          fontWeight: FontWeight.w400,
          fontSize: 14.0,
        ),
      )
      .apply(
        fontFamily: 'Rubik',
        displayColor: kShrineBrown900,
        bodyColor: kShrineBrown900,
      );
}

```