### PR TITLE
Replace custom AccentOverride widget with styling solution

### DIFF
--- a/mdc_100_series/lib/app.dart
+++ b/mdc_100_series/lib/app.dart
@@ -75,6 +75,12 @@ ThemeData _buildShrineTheme() {
         color: kShrineBrown900
     ),
     inputDecorationTheme: InputDecorationTheme(
+      focusedBorder: CutCornersBorder(
+        borderSide: BorderSide(
+          width: 2.0,
+          color: kShrineBrown900,
+        ),
+      ),
       border: CutCornersBorder(),
     ),
     textTheme: _buildShrineTextTheme(base.textTheme),

--- a/mdc_100_series/lib/login.dart
+++ b/mdc_100_series/lib/login.dart
@@ -14,8 +14,6 @@
 
 import 'package:flutter/material.dart';
 
-import 'colors.dart';
-
 class LoginPage extends StatefulWidget {
   @override
   _LoginPageState createState() => _LoginPageState();
@@ -24,6 +22,23 @@ class LoginPage extends StatefulWidget {
 class _LoginPageState extends State<LoginPage> {
   final _usernameController = TextEditingController();
   final _passwordController = TextEditingController();
+  final _unfocusedColor = Colors.grey[600];
+  FocusNode _usernamefocusTracker = FocusNode();
+  FocusNode _passwordfocusTracker = FocusNode();
+
+  @override
+  void initState() {
+    super.initState();
+    _usernamefocusTracker = FocusNode()
+      ..addListener(() {
+        setState(() {});
+      });
+
+    _passwordfocusTracker = FocusNode()
+      ..addListener(() {
+        setState(() {});
+      });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -44,25 +59,27 @@ class _LoginPageState extends State<LoginPage> {
               ],
             ),
             SizedBox(height: 120.0),
-            AccentColorOverride(
-              color: kShrineBrown900,
-              child: TextField(
-                controller: _usernameController,
-                decoration: InputDecoration(
-                  labelText: 'Username',
-                ),
+            TextField(
+              controller: _usernameController,
+              decoration: InputDecoration(
+                labelText: 'Username',
+                labelStyle: _usernamefocusTracker.hasFocus
+                    ? TextStyle(color: Theme.of(context).accentColor)
+                    : TextStyle(color: _unfocusedColor),
               ),
+              focusNode: _usernamefocusTracker,
             ),
             SizedBox(height: 12.0),
-            AccentColorOverride(
-              color: kShrineBrown900,
-              child: TextField(
-                controller: _passwordController,
-                decoration: InputDecoration(
-                  labelText: 'Password',
-                ),
-                obscureText: true,
+            TextField(
+              controller: _passwordController,
+              decoration: InputDecoration(
+                labelText: 'Password',
+                labelStyle: _passwordfocusTracker.hasFocus
+                    ? TextStyle(color: Theme.of(context).accentColor)
+                    : TextStyle(color: _unfocusedColor),
               ),
+              focusNode: _passwordfocusTracker,
+              obscureText: true,
             ),
             ButtonBar(
               children: <Widget>[
@@ -90,25 +107,6 @@ class _LoginPageState extends State<LoginPage> {
             ),
           ],
         ),
-      ),
-    );
-  }
-}
-
-class AccentColorOverride extends StatelessWidget {
-  const AccentColorOverride({Key key, this.color, this.child})
-      : super(key: key);
-
-  final Color color;
-  final Widget child;
-
-  @override
-  Widget build(BuildContext context) {
-    return Theme(
-      child: child,
-      data: Theme.of(context).copyWith(
-        accentColor: color,
-        brightness: Brightness.dark,
       ),
     );
   }

--- a/mdc_100_series/lib/supplemental/product_card.dart
+++ b/mdc_100_series/lib/supplemental/product_card.dart
@@ -53,19 +53,17 @@ class ProductCard extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.end,
             crossAxisAlignment: CrossAxisAlignment.center,
             children: <Widget>[
-              // TODO(larche): Make headline6 when available
               Text(
                 product == null ? '' : product.name,
-                style: theme.textTheme.button,
+                style: theme.textTheme.headline6,
                 softWrap: false,
                 overflow: TextOverflow.ellipsis,
                 maxLines: 1,
               ),
               SizedBox(height: 4.0),
-              // TODO(larche): Make subtitle2 when available
               Text(
                 product == null ? '' : formatter.format(product.price),
-                style: theme.textTheme.caption,
+                style: theme.textTheme.subtitle2,
               ),
             ],
           ),


### PR DESCRIPTION
Fixes #196

- Depends on updating mdc 103 codelab instructions
- Uses styling instead of custom AccentOverride widget to decorate the input text field for username and password.