### PR TITLE
Replace custom AccentOverride widget solution with theme styling solution

### DIFF
--- a/mdc_100_series/lib/app.dart
+++ b/mdc_100_series/lib/app.dart
@@ -75,6 +75,12 @@ ThemeData _buildShrineTheme() {
         color: kShrineBrown900
     ),
     inputDecorationTheme: InputDecorationTheme(
+      focusedBorder: CutCornersBorder(
+        borderSide: BorderSide(
+          width: 2.0,
+          color: kShrineBrown900,
+        ),
+      ),
       border: CutCornersBorder(),
     ),
     textTheme: _buildShrineTextTheme(base.textTheme),

--- a/mdc_100_series/lib/login.dart
+++ b/mdc_100_series/lib/login.dart
@@ -14,8 +14,6 @@
 
 import 'package:flutter/material.dart';
 
-import 'colors.dart';
-
 class LoginPage extends StatefulWidget {
   @override
   _LoginPageState createState() => _LoginPageState();
@@ -24,6 +22,23 @@ class LoginPage extends StatefulWidget {
 class _LoginPageState extends State<LoginPage> {
   final _usernameController = TextEditingController();
   final _passwordController = TextEditingController();
+  final _unfocusedColor = Colors.grey[600];
+  FocusNode _usernamefocusTracker = FocusNode();
+  FocusNode _passwordfocusTracker = FocusNode();
+
+  @override
+  void initState() {
+    super.initState();
+    _usernamefocusTracker = FocusNode()
+      ..addListener(() {
+        setState(() {});
+      });
+
+    _passwordfocusTracker = FocusNode()
+      ..addListener(() {
+        setState(() {});
+      });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -44,25 +59,27 @@ class _LoginPageState extends State<LoginPage> {
               ],
             ),
             SizedBox(height: 120.0),
-            AccentColorOverride(
-              color: kShrineBrown900,
-              child: TextField(
-                controller: _usernameController,
-                decoration: InputDecoration(
-                  labelText: 'Username',
-                ),
+            TextField(
+              controller: _usernameController,
+              decoration: InputDecoration(
+                labelText: 'Username',
+                labelStyle: _usernamefocusTracker.hasFocus
+                    ? TextStyle(color: Theme.of(context).accentColor)
+                    : TextStyle(color: _unfocusedColor),
               ),
+              focusNode: _usernamefocusTracker,
             ),
             SizedBox(height: 12.0),
-            AccentColorOverride(
-              color: kShrineBrown900,
-              child: TextField(
-                controller: _passwordController,
-                decoration: InputDecoration(
-                  labelText: 'Password',
-                ),
-                obscureText: true,
+            TextField(
+              controller: _passwordController,
+              decoration: InputDecoration(
+                labelText: 'Password',
+                labelStyle: _passwordfocusTracker.hasFocus
+                    ? TextStyle(color: Theme.of(context).accentColor)
+                    : TextStyle(color: _unfocusedColor),
               ),
+              focusNode: _passwordfocusTracker,
+              obscureText: true,
             ),
             ButtonBar(
               children: <Widget>[
@@ -90,25 +107,6 @@ class _LoginPageState extends State<LoginPage> {
             ),
           ],
         ),
-      ),
-    );
-  }
-}
-
-class AccentColorOverride extends StatelessWidget {
-  const AccentColorOverride({Key key, this.color, this.child})
-      : super(key: key);
-
-  final Color color;
-  final Widget child;
-
-  @override
-  Widget build(BuildContext context) {
-    return Theme(
-      child: child,
-      data: Theme.of(context).copyWith(
-        accentColor: color,
-        brightness: Brightness.dark,
       ),
     );
   }

--- a/mdc_100_series/lib/login.dart
+++ b/mdc_100_series/lib/login.dart
@@ -23,19 +23,17 @@ class _LoginPageState extends State<LoginPage> {
   final _usernameController = TextEditingController();
   final _passwordController = TextEditingController();
   final _unfocusedColor = Colors.grey[600];
-  FocusNode _usernamefocusTracker = FocusNode();
-  FocusNode _passwordfocusTracker = FocusNode();
+  FocusNode _usernameFocusNode = FocusNode();
+  FocusNode _passwordFocusNode = FocusNode();
 
   @override
   void initState() {
     super.initState();
-    _usernamefocusTracker = FocusNode()
-      ..addListener(() {
+    _usernameFocusNode..addListener(() {
         setState(() {});
       });
 
-    _passwordfocusTracker = FocusNode()
-      ..addListener(() {
+    _passwordFocusNode..addListener(() {
         setState(() {});
       });
   }
@@ -63,22 +61,22 @@ class _LoginPageState extends State<LoginPage> {
               controller: _usernameController,
               decoration: InputDecoration(
                 labelText: 'Username',
-                labelStyle: _usernamefocusTracker.hasFocus
+                labelStyle: _usernameFocusNode.hasFocus
                     ? TextStyle(color: Theme.of(context).accentColor)
                     : TextStyle(color: _unfocusedColor),
               ),
-              focusNode: _usernamefocusTracker,
+              focusNode: _usernameFocusNode,
             ),
             SizedBox(height: 12.0),
             TextField(
               controller: _passwordController,
               decoration: InputDecoration(
                 labelText: 'Password',
-                labelStyle: _passwordfocusTracker.hasFocus
+                labelStyle: _passwordFocusNode.hasFocus
                     ? TextStyle(color: Theme.of(context).accentColor)
                     : TextStyle(color: _unfocusedColor),
               ),
-              focusNode: _passwordfocusTracker,
+              focusNode: _passwordFocusNode,
               obscureText: true,
             ),
             ButtonBar(

--- a/mdc_100_series/lib/login.dart
+++ b/mdc_100_series/lib/login.dart
@@ -23,18 +23,24 @@ class _LoginPageState extends State<LoginPage> {
   final _usernameController = TextEditingController();
   final _passwordController = TextEditingController();
   final _unfocusedColor = Colors.grey[600];
-  FocusNode _usernameFocusNode = FocusNode();
-  FocusNode _passwordFocusNode = FocusNode();
+  final _usernameFocusNode = FocusNode();
+  final _passwordFocusNode = FocusNode();
 
   @override
   void initState() {
     super.initState();
-    _usernameFocusNode..addListener(() {
-        setState(() {});
+    _usernameFocusNode
+      ..addListener(() {
+        setState(() {
+          //Redraw so that the username label reflects the focus state
+        });
       });
 
-    _passwordFocusNode..addListener(() {
-        setState(() {});
+    _passwordFocusNode
+      ..addListener(() {
+        setState(() {
+          //Redraw so that the password label reflects the focus state
+        });
       });
   }
 
@@ -61,9 +67,10 @@ class _LoginPageState extends State<LoginPage> {
               controller: _usernameController,
               decoration: InputDecoration(
                 labelText: 'Username',
-                labelStyle: _usernameFocusNode.hasFocus
-                    ? TextStyle(color: Theme.of(context).accentColor)
-                    : TextStyle(color: _unfocusedColor),
+                labelStyle: TextStyle(
+                    color: _usernameFocusNode.hasFocus
+                        ? Theme.of(context).accentColor
+                        : _unfocusedColor),
               ),
               focusNode: _usernameFocusNode,
             ),
@@ -72,9 +79,10 @@ class _LoginPageState extends State<LoginPage> {
               controller: _passwordController,
               decoration: InputDecoration(
                 labelText: 'Password',
-                labelStyle: _passwordFocusNode.hasFocus
-                    ? TextStyle(color: Theme.of(context).accentColor)
-                    : TextStyle(color: _unfocusedColor),
+                labelStyle: TextStyle(
+                    color: _passwordFocusNode.hasFocus
+                        ? Theme.of(context).accentColor
+                        : _unfocusedColor),
               ),
               focusNode: _passwordFocusNode,
               obscureText: true,


### PR DESCRIPTION
Fixes #196

- Depends on updating mdc 103 codelab instructions
- Uses styling instead of custom AccentOverride widget to decorate the input text field for username and password.