### PR TITLE
Update colors.dart to follow effective dart guidelines 

### DIFF
--- a/mdc_100_series/lib/colors.dart
+++ b/mdc_100_series/lib/colors.dart
@@ -14,14 +14,14 @@
 
 import 'package:flutter/material.dart';
 
-const kShrinePink50 = const Color(0xFFFEEAE6);
-const kShrinePink100 = const Color(0xFFFEDBD0);
-const kShrinePink300 = const Color(0xFFFBB8AC);
-const kShrinePink400 = const Color(0xFFEAA4A4);
+const kShrinePink50 = Color(0xFFFEEAE6);
+const kShrinePink100 = Color(0xFFFEDBD0);
+const kShrinePink300 = Color(0xFFFBB8AC);
+const kShrinePink400 = Color(0xFFEAA4A4);
 
-const kShrineBrown900 = const Color(0xFF442B2D);
+const kShrineBrown900 = Color(0xFF442B2D);
 
-const kShrineErrorRed = const Color(0xFFC5032B);
+const kShrineErrorRed = Color(0xFFC5032B);
 
-const kShrineSurfaceWhite = const Color(0xFFFFFBFA);
+const kShrineSurfaceWhite = Color(0xFFFFFBFA);
 const kShrineBackgroundWhite = Colors.white;


### PR DESCRIPTION
Follow effective dart guidelines on redundant const.

https://dart.dev/guides/language/effective-dart/usage#dont-use-const-redundantly

This closes #204 