### PR TITLE
Fixed error where textTheme and primaryTextTheme was set twice in the 104-complete branch.

### DIFF
--- a/mdc_100_series/lib/app.dart
+++ b/mdc_100_series/lib/app.dart
@@ -96,8 +96,6 @@ ThemeData _buildShrineTheme() {
     inputDecorationTheme: InputDecorationTheme(
       border: CutCornersBorder(),
     ),
-    textTheme: _buildShrineTextTheme(base.textTheme),
-    primaryTextTheme: _buildShrineTextTheme(base.primaryTextTheme),
     accentTextTheme: _buildShrineTextTheme(base.accentTextTheme),
     iconTheme: _customIconTheme(base.iconTheme),
   );


### PR DESCRIPTION
While working through the lab, I found a small error where textTheme and primaryTextTheme were set twice in the function _buildShrineTheme() in the file lib>app.dart. I removed the issue code and am contributing to the source.